### PR TITLE
[FOS-11703] Disable installation of ral2-sample-driver files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-# Provides only a library
-catkin_package(
-  LIBRARIES
-    ral2-sample-driver
-)
-
 # Build 
 include_directories(src)
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
@@ -82,9 +76,6 @@ target_link_libraries(
 set(URDF_DIRECTORIES
   "READY-5.0"
 )
-install_robot_models(URDF_DIRS ${URDF_DIRECTORIES})
-
-# Install
 list(TRANSFORM URDF_DIRECTORIES APPEND ".json" OUTPUT_VARIABLE ROBOT_MODEL_FILES)
 validate_robot_configurations(ROBOT_MODELS ${ROBOT_MODEL_FILES})
 
@@ -92,16 +83,6 @@ SET(CONTROLLER_FILES
   "RCU/Program Mode.json"
 )
 validate_controller_configurations(CONTROLLER_MODELS ${CONTROLLER_FILES})
-
-install(
-  TARGETS ral2-sample-driver
-  LIBRARY DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
-)
-
-install(
-  FILES ${DRFL_LIB}
-  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-)
 
 device_translations(
   ready-ral2-sample-driver
@@ -111,21 +92,40 @@ device_translations(
     configurations/Sample.json
 )
 
-# Install the controller models ahead of the install package
-install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/configurations/controller-models
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/configurations
-)
-
-install_package(
-  ready-ral2-sample-driver
-  manifest.json
-  DIRS
-    ${CMAKE_CURRENT_BINARY_DIR}/configurations
-  VENDOR_ICON
-    READY.svg
-  VENDOR_FILES
-    configurations/Sample.json
-  LOCALE_DIR
-    ${QM_FILE_DIR}
-)
+# -------------------------------------------------------------------------------------
+# Uncomment the following lines to install and test the driver implementation in Forge
+# -------------------------------------------------------------------------------------
+#
+# # Install the package
+# catkin_package(
+#   LIBRARIES
+#     ral2-sample-driver
+# )
+#
+# # Install Robot models
+# install_robot_models(URDF_DIRS ${URDF_DIRECTORIES})
+#
+# # Install the driver implementation
+# install(
+#   TARGETS ral2-sample-driver
+#   LIBRARY DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
+# )
+#
+# # Install the controller models ahead of the install package
+# install(
+#   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/configurations/controller-models
+#   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/configurations
+# )
+#
+# install_package(
+#   ready-ral2-sample-driver
+#   manifest.json
+#   DIRS
+#     ${CMAKE_CURRENT_BINARY_DIR}/configurations
+#   VENDOR_ICON
+#     READY.svg
+#   VENDOR_FILES
+#     configurations/Sample.json
+#   LOCALE_DIR
+#     ${QM_FILE_DIR}
+# )


### PR DESCRIPTION
Blacklisting the ral2-sample-driver in the high-level build configuration would prevent it from building in nightlies and in developer builds. This would defeat the purpose of having it in the workspace at all.

To ensure it builds without appearing in production, all installation directives are commented out.